### PR TITLE
Resolves GH-29: Change assemble task dependency

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - (GH-30) Update minimum required Gradle version to 5.0
+- (GH-29) Switch from assemble depending on the container build task to depending on the container assemble task, which doesn't require docker and is more appropriate
 
 ## [1.0.0]
 ### Changed
 - (GH-25) Update minimum required Gradle version to 4.0
 - (GH-24) Switch clean container tasks from ignoring error input to skipping based on docker images command 
+- Add dependency on `buildContainer` task for default `assemble` task
 
 ## [0.3.0]
 ### Added

--- a/src/main/groovy/org/starchartlabs/flare/publishing/plugin/DockerBuildPlugin.groovy
+++ b/src/main/groovy/org/starchartlabs/flare/publishing/plugin/DockerBuildPlugin.groovy
@@ -62,7 +62,7 @@ public class DockerBuildPlugin implements Plugin<Project> {
 
         // When the base plug-in is applied, attach to the assemble and clean tasks
         project.pluginManager.withPlugin('base', {plugin ->
-            project.tasks.assemble.dependsOn buildAllTask
+            project.tasks.assemble.dependsOn assembleAllTask
             project.tasks.clean.dependsOn cleanAllTask
         });
     }


### PR DESCRIPTION
As of 4.0.0, the base plugin assemble task was set to depend on
buildContainer. This was quite correct, and required docker be present
on any system doing a simple compile/jar step.

This changeset switches assemble to depend on assembleContainer instead,
which is more appropriate to that build level