### PR TITLE
Address GH-38: Docker labels adding extra double quotes

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- (GH-38) Fixed bug where extra quotes were added to Docker labels in Unix environments.
 
 ## [2.0.0]
 ### Changed

--- a/flare-pub-gradle-test/flare-test-subproject2/build.gradle
+++ b/flare-pub-gradle-test/flare-test-subproject2/build.gradle
@@ -14,7 +14,8 @@ containers {
         }
         labels (
             "label1": "one",
-            "label2": "two"
+            "label2": "two",
+            "label 3": "three 3"
         )
     }
 }

--- a/src/main/groovy/org/starchartlabs/flare/publishing/task/ContainerBuildTask.groovy
+++ b/src/main/groovy/org/starchartlabs/flare/publishing/task/ContainerBuildTask.groovy
@@ -59,7 +59,7 @@ public class ContainerBuildTask extends Exec {
             container.getLabels().entrySet()
                     .forEach{e ->
                         currentArgs.add("--label")
-                        currentArgs.add("\"${e.key}=${e.value}\"")
+                        currentArgs.add("${e.key}=${e.value}")
                     }
         }
 

--- a/src/main/groovy/org/starchartlabs/flare/publishing/task/ContainerBuildTask.groovy
+++ b/src/main/groovy/org/starchartlabs/flare/publishing/task/ContainerBuildTask.groovy
@@ -59,7 +59,7 @@ public class ContainerBuildTask extends Exec {
             container.getLabels().entrySet()
                     .forEach{e ->
                         currentArgs.add("--label")
-                        currentArgs.add("${e.key}=${e.value}")
+                        currentArgs.add('"' + "${e.key}=${e.value}" + '"')
                     }
         }
 


### PR DESCRIPTION
Edit so escaping of quotes is not added to the label. 
Adjust test project to include a label with spaces in it.